### PR TITLE
added fix for params - not mandatory

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -33,7 +33,7 @@ module Spree
       find_line_item_by_variant(variant, ad_hoc_option_value_ids, product_customizations).present?
     end
 
-    def find_line_item_by_variant(variant, options={}, ad_hoc_option_value_ids, product_customizations)
+    def find_line_item_by_variant(variant, options={}, ad_hoc_option_value_ids=[], product_customizations=[])
       line_items.detect do |li|
         li.variant_id == variant.id &&
           line_item_options_match(li, options) &&


### PR DESCRIPTION
@basti @draganf 

bug fix for params product_customizations and ad_hoc_option_value_ids, they are not mandatory